### PR TITLE
Fix "TypeError: 'float' object cannot be interpreted as an integer"

### DIFF
--- a/epd2in13/__init__.py
+++ b/epd2in13/__init__.py
@@ -214,7 +214,7 @@ class EPD:
         self.set_memory_pointer(0, 0)
         self.send_command(WRITE_RAM)
         # send the color data
-        for i in range(0, self.width / 8 * self.height):
+        for i in range(0, int(self.width / 8 * self.height)):
             self.send_data(color)
 
 ##


### PR DESCRIPTION
Fix #1 